### PR TITLE
Feature/tests

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -45,6 +45,6 @@ const config = {
 			},
 		},
 	],
-	ignorePatterns: ['demo', 'dist', 'vendor', 'www', '**/*.ejs', '**.config.js', '**.config.ts'],
+	ignorePatterns: ['demo', 'dist', 'vendor', 'www', '**/*.ejs', '**config.js', '**config.ts'],
 };
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"www": "cd www && npm run dev",
 		"build": "tsup src/index.ts --format cjs,esm --dts --no-clean",
 		"test": "find src -name '*.test.ts' | xargs c8 node --import tsx --test",
-		"lint": "eslint ."
+		"lint": "tsc && eslint ."
 	},
 	"devDependencies": {
 		"@types/dompurify": "^3.2.0",

--- a/src/__test__/_test-utils.ts
+++ b/src/__test__/_test-utils.ts
@@ -1,0 +1,25 @@
+import { type Mock, type TestContext } from 'node:test';
+import { NOOP } from '../utilities';
+
+export const getLogMock = (testContext: TestContext) => {
+	testContext.mock.method(console, 'log', NOOP);
+	type MockFunctionContext = Mock<typeof console.log>['mock'];
+	// @ts-expect-error // typescript doesn't honor the node mock
+	return console.log.mock as MockFunctionContext;
+};
+
+export const getWarnMock = (testContext: TestContext) => {
+	testContext.mock.method(console, 'warn', NOOP);
+	type MockFunctionContext = Mock<typeof console.warn>['mock'];
+	// @ts-expect-error // typescript doesn't honor the node mock
+	return console.warn.mock as MockFunctionContext;
+};
+
+export const getErrorMock = (testContext: TestContext) => {
+	testContext.mock.method(console, 'error', NOOP);
+	type MockFunctionContext = Mock<typeof console.error>['mock'];
+	// @ts-expect-error // typescript doesn't honor the node mock
+	return console.error.mock as MockFunctionContext;
+};
+
+export const nextMicrotask = () => new Promise<void>((resolve) => queueMicrotask(resolve));

--- a/src/__test__/custom-element.test.ts
+++ b/src/__test__/custom-element.test.ts
@@ -1,0 +1,51 @@
+import { test } from 'node:test';
+import assert from 'assert';
+import { customElement } from '../custom-element';
+import { html } from '../render';
+import { createRegistry } from '../registry';
+import { getErrorMock } from './_test-utils';
+
+await test('customElement', async () => {
+	await test('does not throw on the server', () => {
+		assert.doesNotThrow(() => customElement(() => html`<div></div>`));
+	});
+	await test('returns an element result class', () => {
+		const MyElement = customElement(() => html`<div></div>`);
+		assert.ok(MyElement);
+		const keys = Object.keys(MyElement);
+		assert(keys.every((key) => ['define', 'register', 'eject'].includes(key)));
+	});
+	await test('supports scoped registries', () => {
+		const registry = createRegistry({ scoped: true });
+		assert.doesNotThrow(() => customElement(() => html`<div></div>`, { shadowRootOptions: { registry } }));
+	});
+	await test('returns self for chaining', () => {
+		const MyElement = customElement(() => html`<div></div>`);
+		const registry = createRegistry();
+		assert.strictEqual(MyElement.define('my-element'), MyElement);
+		assert.strictEqual(MyElement.register(registry), MyElement);
+	});
+	await test('registers the element with a registry', () => {
+		const registry = createRegistry();
+		const MyElement = customElement(() => html`<div></div>`)
+			.register(registry)
+			.define('my-element');
+		assert.strictEqual(registry.getTagName(MyElement), 'MY-ELEMENT');
+	});
+	await test('logs an error when registering after defining in a scoped registry', (t) => {
+		const errorMock = getErrorMock(t);
+		const registry = createRegistry({ scoped: true });
+		const MyElement = customElement(() => html`<div></div>`);
+		MyElement.define('my-element');
+		MyElement.register(registry);
+		assert.strictEqual(errorMock.callCount(), 1);
+		assert.strictEqual(
+			errorMock.calls[0].arguments[0],
+			'Must call `register()` before `define()` for scoped registries.',
+		);
+	});
+	await test('throws an error when ejecting on the server', () => {
+		const MyElement = customElement(() => html`<div></div>`);
+		assert.throws(() => MyElement.eject());
+	});
+});

--- a/src/__test__/registry.test.ts
+++ b/src/__test__/registry.test.ts
@@ -1,0 +1,63 @@
+import { test } from 'node:test';
+import assert from 'assert';
+import { createRegistry } from '../registry';
+import { customElement } from '../custom-element';
+import { html } from '../render';
+import { getWarnMock } from './_test-utils';
+
+await test('createRegistry', async () => {
+	await test('creates a global registry', () => {
+		const registry = createRegistry();
+		assert.ok(registry);
+		assert.strictEqual(registry.scoped, false);
+	});
+	await test('creates a scoped registry', () => {
+		const registry = createRegistry({ scoped: true });
+		assert.ok(registry);
+		assert.strictEqual(registry.scoped, true);
+	});
+	await test('defines a custom element', () => {
+		const registry = createRegistry();
+		const MyElement = customElement(() => html`<div></div>`);
+		assert.doesNotThrow(() => registry.define('my-element', MyElement));
+	});
+	await test('warns about duplicate custom elements', (t) => {
+		const warnMock = getWarnMock(t);
+		const registry = createRegistry();
+		const MyElement = customElement(() => html`<div></div>`);
+		const MyElement2 = customElement(() => html`<div></div>`);
+		registry.define('my-element', MyElement);
+		registry.define('my-element', MyElement2);
+		assert.strictEqual(warnMock.callCount(), 1);
+		assert.strictEqual(
+			warnMock.calls[0].arguments[0],
+			'Custom element tag name "MY-ELEMENT" was already defined. Skipping...',
+		);
+		registry.define('my-element-2', MyElement);
+		assert.strictEqual(warnMock.callCount(), 2);
+		assert.strictEqual(warnMock.calls[1].arguments[0], 'MY-ELEMENT-2 was already defined. Skipping...');
+	});
+	await test('gets the tag name of a custom element', () => {
+		const registry = createRegistry();
+		const tagName = 'my-element';
+		const MyElement = customElement(() => html`<div></div>`);
+		registry.define(tagName, MyElement);
+		const result = registry.getTagName(MyElement);
+		assert.strictEqual(result, tagName.toUpperCase());
+	});
+	await test('gets all tag names defined in the registry', () => {
+		const registry = createRegistry();
+		const MyElement = customElement(() => html`<div></div>`);
+		const MyElement2 = customElement(() => html`<div></div>`);
+		registry.define('my-element', MyElement);
+		registry.define('my-element-2', MyElement2);
+		const result = registry.getAllTagNames();
+		assert.deepStrictEqual(result, ['MY-ELEMENT', 'MY-ELEMENT-2']);
+	});
+	await test('throws an error if ejected on the server', () => {
+		const registry = createRegistry();
+		const MyElement = customElement(() => html`<div></div>`);
+		registry.define('my-element', MyElement);
+		assert.throws(() => registry.eject(), { message: 'Cannot eject a registry on the server.' });
+	});
+});

--- a/src/__test__/render.test.ts
+++ b/src/__test__/render.test.ts
@@ -1,0 +1,64 @@
+import { test } from 'node:test';
+import assert from 'assert';
+import { html, css } from '../render';
+import { getErrorMock } from './_test-utils';
+
+await test('html', async () => {
+	await test('renders a simple string', () => {
+		const result = html`<div></div>`;
+		assert.strictEqual(result, '<div></div>');
+	});
+	await test('renders a string with interpolated values', () => {
+		const result = html`<div>${'Hello, world!'} ${1} ${true}</div>`;
+		assert.strictEqual(result, '<div>Hello, world! 1 true</div>');
+	});
+	await test('logs an error if a non-primitive value is interpolated', (t) => {
+		const mockError = getErrorMock(t);
+		const obj = {};
+		const result = html`<div>${obj}</div>`;
+		assert.strictEqual(result, '<div></div>');
+		assert.strictEqual(mockError.callCount(), 1);
+		assert.strictEqual(
+			mockError.calls[0].arguments[0],
+			'An invalid value was passed to a template function. Non-primitive values are not supported.\n\nValue:\n',
+		);
+		assert.strictEqual(mockError.calls[0].arguments[1], obj);
+	});
+	await test('renders a string with signals', () => {
+		const mockGetter = () => 'Hello, world!';
+		const result = html`<div>${mockGetter}</div>`;
+		assert.strictEqual(result, '<div>Hello, world!</div>');
+	});
+});
+
+await test('css', async () => {
+	await test('renders a simple string', () => {
+		// prettier-ignore
+		const result = css`div { color: red; }`;
+		assert.strictEqual(result, 'div { color: red; }');
+	});
+	await test('renders a string with interpolated values', () => {
+		// prettier-ignore
+		const result = css`div { --str: ${'str'}; --num: ${1}; --bool: ${true}; }`;
+		assert.strictEqual(result, 'div { --str: str; --num: 1; --bool: true; }');
+	});
+	await test('logs an error if a non-primitive value is interpolated', (t) => {
+		const mockError = getErrorMock(t);
+		const obj = {};
+		// prettier-ignore
+		const result = css`div { --obj: ${obj}; }`;
+		assert.strictEqual(result, 'div { --obj: ; }');
+		assert.strictEqual(mockError.callCount(), 1);
+		assert.strictEqual(
+			mockError.calls[0].arguments[0],
+			'An invalid value was passed to a template function. Non-primitive values are not supported.\n\nValue:\n',
+		);
+		assert.strictEqual(mockError.calls[0].arguments[1], obj);
+	});
+	await test('renders a string with signals', () => {
+		const mockGetter = () => 'red';
+		// prettier-ignore
+		const result = css`div { color: ${mockGetter}; }`;
+		assert.strictEqual(result, 'div { color: red; }');
+	});
+});

--- a/src/__test__/server-side.test.ts
+++ b/src/__test__/server-side.test.ts
@@ -14,6 +14,8 @@ import { createRegistry } from '../registry';
 import { DEFAULT_RENDER_OPTIONS } from '../constants';
 import { type ServerRenderOptions } from '../types';
 import { NOOP } from '../utilities';
+import { customElement } from '../custom-element';
+import { html } from '../render';
 
 const stripWhitespace = (template: string) => template.trim().replace(/\s\s+/g, ' ');
 
@@ -178,6 +180,7 @@ await test('serverDefine', async () => {
 				...DEFAULT_RENDER_OPTIONS,
 				attachShadow: false,
 			},
+			elementResult: customElement(() => html`<div></div>`),
 		});
 
 		assert.strictEqual(fn.mock.calls.length, 1);
@@ -194,6 +197,7 @@ await test('serverDefine', async () => {
 			serverRender,
 			options: DEFAULT_RENDER_OPTIONS,
 			parentRegistry,
+			elementResult: customElement(() => html`<div></div>`),
 		});
 
 		const expectedServerRenderOpts = new Map<string, ServerRenderOptions>([
@@ -216,6 +220,7 @@ await test('serverDefine', async () => {
 			serverRender: () => 'inner',
 			options: { ...DEFAULT_RENDER_OPTIONS, attachShadow: false },
 			parentRegistry: scopedRegistry,
+			elementResult: customElement(() => html`<div></div>`),
 		});
 
 		serverDefine({
@@ -223,6 +228,7 @@ await test('serverDefine', async () => {
 			serverRender: () => '<my-element-11></my-element-11>',
 			options: { ...DEFAULT_RENDER_OPTIONS, attachShadow: false },
 			scopedRegistry,
+			elementResult: customElement(() => html`<div></div>`),
 		});
 
 		serverDefineFns.clear();

--- a/src/__test__/signals.test.ts
+++ b/src/__test__/signals.test.ts
@@ -1,23 +1,8 @@
 import { createEffect, createSignal, derived } from '../signals';
-import { type Mock, test, type TestContext } from 'node:test';
+import { test } from 'node:test';
 import assert from 'assert';
-import { assumeObj, NOOP } from '../utilities';
-
-const getLogMock = (testContext: TestContext) => {
-	testContext.mock.method(console, 'log', NOOP);
-	type MockFunctionContext = Mock<typeof console.log>['mock'];
-	// @ts-expect-error // typescript doesn't honor the node mock
-	return console.log.mock as MockFunctionContext;
-};
-
-const getErrorMock = (testContext: TestContext) => {
-	testContext.mock.method(console, 'error', NOOP);
-	type MockFunctionContext = Mock<typeof console.error>['mock'];
-	// @ts-expect-error // typescript doesn't honor the node mock
-	return console.error.mock as MockFunctionContext;
-};
-
-const nextMicrotask = () => new Promise<void>((resolve) => queueMicrotask(resolve));
+import { assumeObj } from '../utilities';
+import { getErrorMock, getLogMock, nextMicrotask } from './_test-utils';
 
 await test('createSignal', async () => {
 	await test('initial value', () => {

--- a/src/__test__/utilities.test.ts
+++ b/src/__test__/utilities.test.ts
@@ -1,0 +1,14 @@
+import { test } from 'node:test';
+import assert from 'assert';
+import { assumeObj, NOOP } from '../utilities';
+
+await test('assumeObj', () => {
+	const obj = assumeObj({ a: 1 });
+	assert.strictEqual(obj.a, 1);
+	assert.strictEqual(obj.b, undefined);
+	assert.throws(() => assumeObj(null), { message: 'Expected an object.' });
+});
+
+await test('NOOP', () => {
+	assert.strictEqual(NOOP(), undefined);
+});

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import { type RenderOptions } from './types';
+import type { RenderOptions } from './types';
 
 export const DEFAULT_RENDER_OPTIONS: RenderOptions = {
 	formAssociated: false,

--- a/src/custom-element.ts
+++ b/src/custom-element.ts
@@ -67,6 +67,7 @@ export const customElement = <Props extends CustomElementProps>(
 					options: allOptions,
 					scopedRegistry,
 					parentRegistry: _registry,
+					elementResult: this,
 				});
 				return this;
 			},

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,5 +1,5 @@
 import { isServer } from './server-side';
-import { type ElementResult, type RegistryArgs, type RegistryResult } from './types';
+import type { TagName, ElementResult, RegistryArgs, RegistryResult } from './types';
 
 /**
  * Create a registry for custom elements.
@@ -18,9 +18,9 @@ import { type ElementResult, type RegistryArgs, type RegistryResult } from './ty
  */
 export const createRegistry = (args?: RegistryArgs): RegistryResult => {
 	const { scoped = false } = args ?? {};
-	const customElementMap = new Map<CustomElementConstructor, string>();
-	const elementResultMap = new Map<ElementResult, string>();
-	const customElementTags = new Set<string>();
+	const customElementMap = new Map<CustomElementConstructor, TagName>();
+	const elementResultMap = new Map<ElementResult, TagName>();
+	const customElementTags = new Set<TagName>();
 	const nativeRegistry = (() => {
 		if (isServer) return;
 		if (scoped) return new CustomElementRegistry();
@@ -31,7 +31,7 @@ export const createRegistry = (args?: RegistryArgs): RegistryResult => {
 		__serverRenderOpts: new Map(),
 		define(tagName, ElementResult, options) {
 			const isResult = 'eject' in ElementResult;
-			const upperCaseTagName = tagName.toUpperCase();
+			const upperCaseTagName = tagName.toUpperCase() as TagName;
 
 			if (customElementTags.has(upperCaseTagName)) {
 				console.warn(`Custom element tag name "${upperCaseTagName}" was already defined. Skipping...`);

--- a/src/render.ts
+++ b/src/render.ts
@@ -1,6 +1,6 @@
 import { isServer } from './server-side';
 import { createEffect } from './signals';
-import { type ElementParent, type Styles, type SignalGetter } from './types';
+import type { ElementParent, Styles, SignalGetter } from './types';
 
 export const clearHTML = (element: ElementParent) => {
 	while (element.childNodes.length > 0) {

--- a/src/server-side.ts
+++ b/src/server-side.ts
@@ -17,8 +17,18 @@ export const onServerDefine = (fn: ServerDefineFn) => {
 	serverDefineFns.add(fn);
 };
 
-export const serverDefine = ({ tagName, serverRender, options, scopedRegistry, parentRegistry }: ServerDefineArgs) => {
+export const serverDefine = ({
+	tagName,
+	serverRender,
+	options,
+	elementResult,
+	scopedRegistry,
+	parentRegistry,
+}: ServerDefineArgs) => {
 	if (parentRegistry !== undefined) {
+		if (parentRegistry.getTagName(elementResult) !== tagName.toUpperCase()) {
+			parentRegistry.define(tagName, elementResult);
+		}
 		parentRegistry.__serverRenderOpts.set(tagName, { serverRender, ...options });
 		if (parentRegistry.scoped) return;
 	}

--- a/src/signals.ts
+++ b/src/signals.ts
@@ -1,4 +1,4 @@
-import { type Signal, type SignalGetter, type SignalOptions, type SignalSetter } from './types';
+import type { Signal, SignalGetter, SignalOptions, SignalSetter } from './types';
 
 let subscriber: (() => void) | null = null;
 const updateQueue = new Set<() => void>();

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -71,31 +71,32 @@ export type ServerRenderFunction = (args: RenderArgs<CustomElementProps>) => str
 export type ServerRenderOptions = { serverRender: ServerRenderFunction } & RenderOptions;
 
 export type ServerDefineArgs = {
-	tagName: string;
+	tagName: TagName;
 	serverRender: ServerRenderFunction;
 	options: RenderOptions;
+	elementResult: ElementResult;
 	scopedRegistry?: RegistryResult;
 	parentRegistry?: RegistryResult;
 };
 
-export type ServerDefineFn = (tagName: string, htmlString: string) => void;
+export type ServerDefineFn = (tagName: TagName, htmlString: string) => void;
 
 export type WrapTemplateArgs = {
-	tagName: string;
+	tagName: TagName;
 	serverRender: ServerRenderFunction;
 	options: RenderOptions;
 };
 
 export type RegistryResult = {
-	__serverCss: Map<string, string[]>;
-	__serverRenderOpts: Map<string, ServerRenderOptions>;
+	__serverCss: Map<TagName, string[]>;
+	__serverRenderOpts: Map<TagName, ServerRenderOptions>;
 	define: (
 		tagName: TagName,
 		CustomElement: CustomElementConstructor | ElementResult,
 		options?: ElementDefinitionOptions,
 	) => RegistryResult;
-	getTagName: (CustomElement: CustomElementConstructor | ElementResult) => string | undefined;
-	getAllTagNames: () => string[];
+	getTagName: (CustomElement: CustomElementConstructor | ElementResult) => TagName | undefined;
+	getAllTagNames: () => TagName[];
 	eject: () => CustomElementRegistry;
 	scoped: boolean;
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
 		"rootDir": "./src"
 	},
 	"include": ["src"],
-	"exclude": ["node_modules"]
+	"exclude": ["node_modules", "__test__"]
 }


### PR DESCRIPTION
This introduces more unit tests for the functionality that can be tested on the server. More tests will need to be added after establishing a way to use a browser environment.

While writing tests, small bugs were discovered:

- `ElementResult.define()` did not properly define the element in its parent registry in all scenarios on the server.
- `RegistryResult.define()` did not properly track tag names and classes on the server, as it was called out of order.